### PR TITLE
Fix: Return shop items from bcc-shops:GetItemsForShop RPC

### DIFF
--- a/client/menus/NPCShopMenus.lua
+++ b/client/menus/NPCShopMenus.lua
@@ -49,7 +49,7 @@ function OpenNPCBuySellMenu(shopName)
             devPrint("Fetching items from DB for edit menu: " .. shopName)
 
             BccUtils.RPC:Call("bcc-shops:GetItemsForShop", { shopName = shopName }, function(success, result)
-                if not success then
+                if not success or type(result) ~= "table" then
                     Notify(result or "Failed to fetch items.", "error")
                     return
                 end
@@ -79,6 +79,7 @@ function OpenNPCBuySellMenu(shopName)
 
                 BCCShopsMainMenu:Open({ startupPage = editListPage })
             end)
+
         end)
     else
         devPrint("Player is not an admin, hiding admin options for store: " .. shopName)

--- a/server/services/fetch.lua
+++ b/server/services/fetch.lua
@@ -406,8 +406,7 @@ BccUtils.RPC:Register("bcc-shops:GetItemsForShop", function(data, cb, src)
                 return cb(false)
             end
 
-            cb(true)
-        end)
+            cb(true, itemResults)
     end)
 end)
 


### PR DESCRIPTION
Previously, the GetItemsForShop RPC returned success=true without sending the actual item data, which caused a nil table error client-side.

This update ensures that itemResults are passed back to the client correctly for editing NPC shop items.