### PR TITLE
Update fetch.lua

### DIFF
--- a/server/services/fetch.lua
+++ b/server/services/fetch.lua
@@ -407,6 +407,7 @@ BccUtils.RPC:Register("bcc-shops:GetItemsForShop", function(data, cb, src)
             end
 
             cb(true, itemResults)
+        end)
     end)
 end)
 


### PR DESCRIPTION
fix for bcc-shops:GetItemsForShop

After update to 1.0.1 I get an error while Server-Startup
[    script:bcc-shops] Error parsing script @bcc-shops/server/services/fetch.lua in resource bcc-shops: @bcc-shops/server/services/fetch.lua:438: 'end' expected (to close 'function' at line 390) near <eof>
