### PR TITLE
fix SQL query in bcc-shops:EditIemNPCShop

### DIFF
--- a/server/services/modify.lua
+++ b/server/services/modify.lua
@@ -1326,7 +1326,7 @@ BccUtils.RPC:Register("bcc-shops:EditItemNPCShop", function(params, cb, src)
 
         MySQL.update([[
             UPDATE bcc_shop_items
-            SET item_label = ?, buy_price = ?, sell_price = ?, category = ?,
+            SET item_label = ?, buy_price = ?, sell_price = ?, category_id = ?,
                 level_required = ?, buy_quantity = ?, sell_quantity = ?
             WHERE shop_id = ? AND item_name = ?
         ]], {


### PR DESCRIPTION
A minor typo that would block editing an item in the shop completely. 

Affected method: server/services/modify.lua:bcc-shops:EditIemNPCShop

